### PR TITLE
update: 新增mqtt的username参数; fix: 修复网络端发送数据首字节为0丢数据.

### DIFF
--- a/code/dtu.py
+++ b/code/dtu.py
@@ -146,6 +146,7 @@ class Dtu(Singleton):
                                 int(cloud_config.get("port", 1883)),
                                 cloud_config.get("clean_session"),
                                 client_id,
+                                cloud_config.get("username"),
                                 cloud_config.get("password"),
                                 cloud_config.get("publish"),
                                 cloud_config.get("subscribe"),

--- a/code/dtu_config.json
+++ b/code/dtu_config.json
@@ -82,6 +82,7 @@
         "server": "dbb-rmqx.iwosai.com",
         "port": "4883",
         "client_id": "2ff01e56-e02a-4919-935d-de1f2677b4f9",
+        "username": "test",
         "password": "NvEpDpATJ8Zyyqjt",
         "clean_session": false,
         "qos": "0",

--- a/code/dtu_transaction.py
+++ b/code/dtu_transaction.py
@@ -101,7 +101,6 @@ class DownlinkTransaction(Singleton):
             data = kwargs["data"]
         else:
             data = str(kwargs["data"])
-        
 
         if cloud_type == "tcp_private_cloud":
             packed_data = data

--- a/code/modules/mqttIot.py
+++ b/code/modules/mqttIot.py
@@ -54,7 +54,7 @@ class MqttIot(CloudObservable):
         4. cloud.post_data(data)
         5. cloud.close()
     """
-    def __init__(self, server, qos, port, clean_session, client_id, pass_word, pub_topic=None, sub_topic=None, life_time=120):
+    def __init__(self, server, qos, port, clean_session, client_id, user, pass_word, pub_topic=None, sub_topic=None, life_time=120):
         """
         1. Init parent class CloudObservable
         2. Init cloud connect params and topic
@@ -63,7 +63,7 @@ class MqttIot(CloudObservable):
         self.conn_type = "mqtt"
         self.__pk = None
         self.__ps = None
-        self.__dk = None
+        self.__dk = user
         self.__ds = None
         self.__server = server
         self.__qos = qos
@@ -97,10 +97,6 @@ class MqttIot(CloudObservable):
             data: response dictionary info
         """
         topic = topic.decode()
-        try:
-            data = ujson.loads(data)
-        except:
-            pass
 
         try:
             self.notifyObservers(self, *("raw_data", {"topic":topic, "data":data} ) )

--- a/dtu_gui/build.sh
+++ b/dtu_gui/build.sh
@@ -1,0 +1,1 @@
+pyinstaller -Fw dtu_gui.py -i quectel.ico

--- a/dtu_gui/cloud_config.py
+++ b/dtu_gui/cloud_config.py
@@ -144,34 +144,39 @@ class CloudConfig(object):
 
             'wx.StaticText({}, wx.ID_ANY, "服务器的端口号", pos=(20, {}+30))'.format(panel, vertical_start_pos),
             'wx.TextCtrl({}, 804, "", pos=(170, {}+30))'.format(panel, vertical_start_pos),
-            'wx.StaticText({}, wx.ID_ANY, u"提示：端口号范围 1~65536", pos=(290, {}+30))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"提示：端口号范围 1~65536", pos=(290, {}+30))'.format(panel,
+                                                                                                vertical_start_pos),
 
             'wx.StaticText({}, wx.ID_ANY, "client_id", pos=(20, {}+60))'.format(panel, vertical_start_pos),
             'wx.TextCtrl({}, 805, "", pos=(170, {}+60))'.format(panel, vertical_start_pos),
             'wx.StaticText({}, wx.ID_ANY, u"提示：自定义客户端", pos=(290, {}+60))'.format(panel, vertical_start_pos),
 
-            'wx.StaticText({}, wx.ID_ANY, "password", pos=(20, {}+90))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, "username", pos=(20, {}+90))'.format(panel, vertical_start_pos),
             'wx.TextCtrl({}, 806, "", pos=(170, {}+90))'.format(panel, vertical_start_pos),
-            'wx.StaticText({}, wx.ID_ANY, u"提示：在服务器上注册的密码", pos=(290, {}+90))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"提示：在服务器上注册的用户名", pos=(290, {}+90))'.format(panel, vertical_start_pos),
 
-            'wx.StaticText({}, wx.ID_ANY, "keep_alive", pos=(20, {}+120))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, "password", pos=(20, {}+120))'.format(panel, vertical_start_pos),
             'wx.TextCtrl({}, 807, "", pos=(170, {}+120))'.format(panel, vertical_start_pos),
-            'wx.StaticText({}, wx.ID_ANY, u"提示：客户端的请求超时时间，默认300s,可选", pos=(290, {}+120))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"提示：在服务器上注册的密码", pos=(290, {}+120))'.format(panel, vertical_start_pos),
 
-            'wx.StaticText({}, wx.ID_ANY, u"clean_session", pos=(20, {}+150))'.format(panel, vertical_start_pos),
-            'wx.ComboBox({}, 808, choices=["0", "1"], style=wx.CB_READONLY, pos=(170, {}+150))'.format(panel, vertical_start_pos),
-            'wx.StaticText({}, wx.ID_ANY, u"提示：MQTT是否保存会话标志位，默认为0 可选", pos=(290, {}+150))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, "keep_alive", pos=(20, {}+150))'.format(panel, vertical_start_pos),
+            'wx.TextCtrl({}, 808, "", pos=(170, {}+150))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"提示：客户端的请求超时时间，默认300s,可选", pos=(290, {}+150))'.format(panel, vertical_start_pos),
 
-            'wx.StaticText({}, wx.ID_ANY, u"QOS", pos=(20, {}+180))'.format(panel, vertical_start_pos),
-            'wx.ComboBox({}, 809, choices=["0", "1", "2"], style=wx.CB_READONLY, pos=(170, {}+180))'.format(panel, vertical_start_pos),
-            'wx.StaticText({}, wx.ID_ANY, u"提示：MQTT的QOS级别，默认0，可选", pos=(290, {}+180))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"clean_session", pos=(20, {}+180))'.format(panel, vertical_start_pos),
+            'wx.ComboBox({}, 809, choices=["0", "1"], style=wx.CB_READONLY, pos=(170, {}+180))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"提示：MQTT是否保存会话标志位，默认为0 可选", pos=(290, {}+180))'.format(panel, vertical_start_pos),
 
-            'wx.StaticText({}, wx.ID_ANY, u"订阅主题", pos=(20, {}+210))'.format(panel, vertical_start_pos),
-            'wx.TextCtrl({}, 810, "", pos=(170, {}+210), size=wx.Size(320, -1))'.format(panel, vertical_start_pos),
-            'wx.StaticText({}, wx.ID_ANY, u"提示：多主题请使用逗号分割", pos=(500, {}+210))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"QOS", pos=(20, {}+210))'.format(panel, vertical_start_pos),
+            'wx.ComboBox({}, 810, choices=["0", "1", "2"], style=wx.CB_READONLY, pos=(170, {}+210))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"提示：MQTT的QOS级别，默认0，可选", pos=(290, {}+210))'.format(panel, vertical_start_pos),
 
-            'wx.StaticText({}, wx.ID_ANY, u"发布主题", pos=(20, {}+240))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"订阅主题", pos=(20, {}+240))'.format(panel, vertical_start_pos),
             'wx.TextCtrl({}, 811, "", pos=(170, {}+240), size=wx.Size(320, -1))'.format(panel, vertical_start_pos),
-            'wx.StaticText({}, wx.ID_ANY, u"提示：注意主题的格式", pos=(500, {}+240))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"提示：自定义主题id为key，主题字符串为value的json格式", pos=(500, {}+240))'.format(panel, vertical_start_pos),
+
+            'wx.StaticText({}, wx.ID_ANY, u"发布主题", pos=(20, {}+270))'.format(panel, vertical_start_pos),
+            'wx.TextCtrl({}, 811, "", pos=(170, {}+270), size=wx.Size(320, -1))'.format(panel, vertical_start_pos),
+            'wx.StaticText({}, wx.ID_ANY, u"提示：自定义主题id为key，主题字符串为value的json格式", pos=(500, {}+270))'.format(panel, vertical_start_pos)
         ]
         return mqtt_list

--- a/dtu_gui/dtu_gui.py
+++ b/dtu_gui/dtu_gui.py
@@ -624,20 +624,22 @@ class dtu_gui_frame(wx.Frame):
             label_list_get[4].write(cloud_config["port"])
         if cloud_config["client_id"] != "":
             label_list_get[7].write(cloud_config["client_id"])
+        if cloud_config["username"] != "":
+            label_list_get[10].write(cloud_config["username"])
         if cloud_config["password"] != "":
-            label_list_get[10].write(cloud_config["password"])
-        label_list_get[13].write(str(cloud_config["keep_alive"]))
+            label_list_get[13].write(cloud_config["password"])
+        label_list_get[16].write(str(cloud_config["keep_alive"]))
         if cloud_config["clean_session"] == 1:
-            label_list_get[16].SetSelection(1)
-        elif cloud_config["clean_session"] == 0:
-            label_list_get[16].SetSelection(0)
-        if cloud_config["qos"] == 1:
             label_list_get[19].SetSelection(1)
-        elif cloud_config["qos"] == 0:
+        elif cloud_config["clean_session"] == 0:
             label_list_get[19].SetSelection(0)
-       
-        label_list_get[22].write(json.dumps(cloud_config["subscribe"]))
-        label_list_get[25].write(json.dumps(cloud_config["publish"]))
+        if cloud_config["qos"] == 1:
+            label_list_get[22].SetSelection(1)
+        elif cloud_config["qos"] == 0:
+            label_list_get[22].SetSelection(0)
+
+        label_list_get[25].write(json.dumps(cloud_config["subscribe"]))
+        label_list_get[28].write(json.dumps(cloud_config["publish"]))
 
     def __fill_huawei_config(self, cloud_config):
         label_list_get = eval("label_list")
@@ -934,12 +936,13 @@ class dtu_gui_frame(wx.Frame):
             "server": label_list_get[1].GetValue(),
             "port": label_list_get[4].GetValue(),
             "client_id": label_list_get[7].GetValue(),
-            "password": label_list_get[10].GetValue(),
-            "clean_session": True if label_list_get[16].GetSelection()==1 else False,
-            "qos": int(label_list_get[19].GetStringSelection()),
-            "keep_alive": int(label_list_get[13].GetValue()),
-            "subscribe": json.loads(label_list_get[22].GetValue()),
-            "publish": json.loads(label_list_get[25].GetValue()),
+            "username": label_list_get[10].GetValue(),
+            "password": label_list_get[13].GetValue(),
+            "clean_session": True if label_list_get[19].GetSelection() == 1 else False,
+            "qos": int(label_list_get[22].GetStringSelection()),
+            "keep_alive": int(label_list_get[16].GetValue()),
+            "subscribe": json.loads(label_list_get[25].GetValue()),
+            "publish": json.loads(label_list_get[28].GetValue()),
         }
         print("mqtt_config:", mqtt_config)
         return mqtt_config


### PR DESCRIPTION
1、新增mqtt的username参数；
涉及变更：
        a、mqttIot模块，新增username链接参数
        b、上位机工具界面新增mqtt的username链接参数

2、修复"网络端发送数据首字节为0丢数据"。
原因：mqtt下行时数据回调函数中，使用ujson解码数据，如果数据是b"0987654321"，ujson会按照整数类型解析，字符串"0987654321"被解析为整数987654321（丢弃高位无效0）。
解决方法：在mqtt下行数据回调函数内部不对消息携带的data做处理，直接按照原生字节传递给下行数据执行器处理。